### PR TITLE
Properly register the extension for display test

### DIFF
--- a/mod/src/main/java/zsawyer/mods/mumblelink/MumbleLinkImpl.java
+++ b/mod/src/main/java/zsawyer/mods/mumblelink/MumbleLinkImpl.java
@@ -26,12 +26,16 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ExtensionPoint;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.network.FMLNetworkConstants;
 import net.minecraftforge.forgespi.language.IModInfo;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import zsawyer.mods.mumblelink.api.MumbleLink;
@@ -58,6 +62,7 @@ public class MumbleLinkImpl extends MumbleLinkBase implements MumbleLink {
 
     public MumbleLinkImpl() {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
+        this.preInit();
         instance = this;
     }
 
@@ -71,7 +76,6 @@ public class MumbleLinkImpl extends MumbleLinkBase implements MumbleLink {
     @SubscribeEvent(priority = EventPriority.NORMAL)
     public void setup(FMLClientSetupEvent event) {
         LOG.debug("setup started");
-        preInit();
         if (enabled) {
             load(event);
             LOG.info("loaded and active");
@@ -80,7 +84,10 @@ public class MumbleLinkImpl extends MumbleLinkBase implements MumbleLink {
     }
 
     public void preInit() {
-        IModInfo modInfo = ModLoadingContext.get().getActiveContainer().getModInfo();
+        ModLoadingContext context = ModLoadingContext.get();
+        context.registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () -> Pair.of(
+            () -> FMLNetworkConstants.IGNORESERVERONLY, (serverVer, isDedicated) -> true));
+        IModInfo modInfo = context.getActiveContainer().getModInfo();
         name = modInfo.getDisplayName();
         version = modInfo.getVersion().getQualifier();
         loadConfig();

--- a/mod/src/main/java/zsawyer/mods/mumblelink/addons/pa/es/ExtendedPASupport.java
+++ b/mod/src/main/java/zsawyer/mods/mumblelink/addons/pa/es/ExtendedPASupport.java
@@ -27,6 +27,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ExtensionPoint;
 import net.minecraftforge.fml.ModContainer;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.ModLoadingContext;
@@ -35,7 +36,10 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.fml.network.FMLNetworkConstants;
 import net.minecraftforge.forgespi.language.IModInfo;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import zsawyer.mods.mumblelink.api.Activateable;
@@ -82,6 +86,7 @@ public class ExtendedPASupport implements Activateable, IdentityManipulator {
 
     public ExtendedPASupport() {
         FMLJavaModLoadingContext.get().getModEventBus().addListener(EventPriority.LOWEST, this::setup);
+        this.preInit();
     }
 
     @OnlyIn(Dist.CLIENT)
@@ -89,7 +94,6 @@ public class ExtendedPASupport implements Activateable, IdentityManipulator {
     public void setup(InterModEnqueueEvent event) {
         LOG.debug("setup started");
         try {
-            preInit();
             if (enabled) {
                 load();
                 LOG.info("loaded and active");
@@ -103,6 +107,9 @@ public class ExtendedPASupport implements Activateable, IdentityManipulator {
     }
 
     public void preInit() {
+        ModLoadingContext context = ModLoadingContext.get();
+        context.registerExtensionPoint(ExtensionPoint.DISPLAYTEST, () -> Pair.of(
+            () -> FMLNetworkConstants.IGNORESERVERONLY, (serverVer, isDedicated) -> true));
         IModInfo modInfo = ModLoadingContext.get().getActiveContainer().getModInfo();
         name = modInfo.getDisplayName();
         version = modInfo.getVersion().getQualifier();


### PR DESCRIPTION
Under the Forge framework, `ExtensionPoint.DISPLAYTEST` is used during server handshaking period.
The result of this test will determine "whether forge will display a green check mark, indicating compatibility", as shown below (before this PR):

![2020-05-22_18 11 26](https://user-images.githubusercontent.com/9113033/82718499-ad315280-9c57-11ea-9069-5eb883344fbb.png)

Do note that this display does not stop you from joining the server; it is only a bit misleading to average users. After this PR, Forge should give you a green check mark instead.

(I'd like to help cleaning up the codebase as well. However, I would like to make that a separate PR for that one.)

Ref: https://mcforge.readthedocs.io/en/1.14.x/concepts/sides/#writing-one-sided-mods