### PR TITLE
Dimensional Height Offset

### DIFF
--- a/mod/build.gradle
+++ b/mod/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'idea'
 apply plugin: 'maven-publish'
 
-ext.modversion = "4.4.1"
+ext.modversion = "4.5.0"
 ext.mcversion = "1.15.2"
 ext.forgeversion = "31.1.0"
 

--- a/mod/build.gradle
+++ b/mod/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'idea'
 apply plugin: 'maven-publish'
 
-ext.modversion = "4.5.0"
+ext.modversion = "5.0.0"
 ext.mcversion = "1.15.2"
 ext.forgeversion = "31.1.0"
 


### PR DESCRIPTION
Added distribution of different dimensions over positional audio height range.
- This means that players that are in different dimensions should not hear each other if they are in a Vanilla dimension and otherwise are rather unlikely to hear each other.
- DIM0 (Overworld) remains on offset 0 so positional audio for the Overworld does not change.
- All players must use the same version of the mod for positional audio to work at all in non-Overworld dimensions.
- Changed version number accordingly.