### PR TITLE
Support to 1.18.2 and 1.19.3

### DIFF
--- a/mod/build.gradle
+++ b/mod/build.gradle
@@ -18,10 +18,10 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'idea'
 apply plugin: 'maven-publish'
 
-ext.modversion              = "5.2.0"
-ext.mcversion               = "1.18.2"
-ext.forgeversion_dependency = "40"
-ext.forgeversion            = "40.2.0"
+ext.modversion              = "5.3.0"
+ext.mcversion               = "1.19.3"
+ext.forgeversion_dependency = "44"
+ext.forgeversion            = "44.1.0"
 
 version = mcversion + "-" + modversion
 group = "zsawyer.mods.mumblelink.MumbleLink"

--- a/mod/build.gradle
+++ b/mod/build.gradle
@@ -18,17 +18,17 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'idea'
 apply plugin: 'maven-publish'
 
-ext.modversion              = "5.1.0"
-ext.mcversion               = "1.17.1"
-ext.forgeversion_dependency = "37"
-ext.forgeversion            = "37.0.43"
+ext.modversion              = "5.2.0"
+ext.mcversion               = "1.18.2"
+ext.forgeversion_dependency = "40"
+ext.forgeversion            = "40.2.0"
 
 version = mcversion + "-" + modversion
 group = "zsawyer.mods.mumblelink.MumbleLink"
 archivesBaseName = "mumblelink"
 ext.vendorName = "zsawyer." + archivesBaseName
 
-java.toolchain.languageVersion = JavaLanguageVersion.of(16)
+java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + '(' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
 minecraft {

--- a/mod/gradle/wrapper/gradle-wrapper.properties
+++ b/mod/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.2-20210702220150+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mod/src/main/java/zsawyer/mods/mumblelink/MumbleLinkImpl.java
+++ b/mod/src/main/java/zsawyer/mods/mumblelink/MumbleLinkImpl.java
@@ -32,7 +32,7 @@ import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
-import net.minecraftforge.fmllegacy.network.FMLNetworkConstants;
+import net.minecraftforge.network.NetworkConstants;
 import net.minecraftforge.forgespi.language.IModInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -85,7 +85,7 @@ public class MumbleLinkImpl extends MumbleLinkBase implements MumbleLink {
         ModLoadingContext context = ModLoadingContext.get();
         context.registerExtensionPoint(IExtensionPoint.DisplayTest.class
                 , () -> new IExtensionPoint.DisplayTest(
-                        () -> FMLNetworkConstants.IGNORESERVERONLY,
+                        () -> NetworkConstants.IGNORESERVERONLY,
                         (serverVer, isDedicated) -> true));
         IModInfo modInfo = context.getActiveContainer().getModInfo();
         name = modInfo.getDisplayName();

--- a/mod/src/main/java/zsawyer/mods/mumblelink/addons/pa/es/ExtendedPASupport.java
+++ b/mod/src/main/java/zsawyer/mods/mumblelink/addons/pa/es/ExtendedPASupport.java
@@ -32,7 +32,7 @@ import net.minecraftforge.fml.*;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
-import net.minecraftforge.fmllegacy.network.FMLNetworkConstants;
+import net.minecraftforge.network.NetworkConstants;
 import net.minecraftforge.forgespi.language.IModInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -104,7 +104,7 @@ public class ExtendedPASupport implements Activateable, IdentityManipulator {
         ModLoadingContext context = ModLoadingContext.get();
         context.registerExtensionPoint(IExtensionPoint.DisplayTest.class
                 , () -> new IExtensionPoint.DisplayTest(
-                        () -> FMLNetworkConstants.IGNORESERVERONLY,
+                        () -> NetworkConstants.IGNORESERVERONLY,
                         (serverVer, isDedicated) -> true));
         IModInfo modInfo = ModLoadingContext.get().getActiveContainer().getModInfo();
         name = modInfo.getDisplayName();

--- a/mod/src/main/java/zsawyer/mods/mumblelink/notification/ChatNotifier.java
+++ b/mod/src/main/java/zsawyer/mods/mumblelink/notification/ChatNotifier.java
@@ -22,7 +22,7 @@
 package zsawyer.mods.mumblelink.notification;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.Component;
 
 /**
  * @author zsawyer
@@ -51,7 +51,6 @@ public class ChatNotifier implements UserNotifier {
     }
 
     protected void send(String message) {
-        TextComponent messageObject = new TextComponent(message);
-        game.gui.getChat().addMessage(messageObject);
+        game.gui.getChat().addMessage(Component.literal(message));
     }
 }


### PR DESCRIPTION
*Adds support to Minecraft 1.18.2 and 1.19.3*

**Upgrade gradle (commit  6bb356a)**
I updated gradle to 7.4.2

**1.18.2 (commit 084db64)**
I updated forge version to 40.2.0 and JDK to 17.
I changed:
- import net.minecraftforge.fmllegacy.network.FMLNetworkConstants to import net.minecraftforge.network.NetworkConstants
- FMLNetworkConstants.IGNORESERVERONLY to NetworkConstants.IGNORESERVERONLY

In:
- MumbleLinkImpl.java
- ExtendedPASupport.java

**1.19.3 (commit  326eb85)**
I updated forge version to 44.1.0.
I changed: 
- import net.minecraft.network.chat.TextComponent to import net.minecraft.network.chat.Component
- TextComponent messageObject = new TextComponent(message);
  game.gui.getChat().addMessage(messageObject);
to
   game.gui.getChat().addMessage(Component.literal(message));

In ChatNotifier.java